### PR TITLE
Add return statement for begin and LoRaConfig

### DIFF
--- a/SX126x.cpp
+++ b/SX126x.cpp
@@ -62,6 +62,7 @@ int16_t SX126x::begin(uint8_t packetType, uint32_t frequencyInHz, int8_t txPower
                   SX126X_IRQ_NONE); //interrupts on DIO3
 
   SetRfFrequency(frequencyInHz);
+  return ERR_NONE;
 }
 
 
@@ -105,6 +106,7 @@ int16_t SX126x::LoRaConfig(uint8_t spreadingFactor, uint8_t bandwidth, uint8_t c
                   SX126X_IRQ_NONE);
   //receive state no receive timeoout
   SetRx(0xFFFFFF);
+  return ERR_NONE;
 }
 
 


### PR DESCRIPTION
No return statement in a value-returning function is a undefined behavior.  
It's not only cause warning messages, but also cause serious bug in STM32 Arduino environment.  
https://stackoverflow.com/questions/1610030/why-does-flowing-off-the-end-of-a-non-void-function-without-returning-a-value-no
